### PR TITLE
Update lpaq2g-wiese.cpp

### DIFF
--- a/lpaq2g-wiese.cpp
+++ b/lpaq2g-wiese.cpp
@@ -19,7 +19,7 @@
 #endif
 
 #ifndef _WIN32
-#define _aligned_malloc(x,y) aligned_alloc(y,x)
+#define _aligned_malloc(x,y) memalign(y,x)
 #define _aligned_free(x) free(x)
 #endif
 


### PR DESCRIPTION
error: use of undeclared identifier 'aligned_alloc'